### PR TITLE
Suppress mentions in /leaderboard

### DIFF
--- a/app.js
+++ b/app.js
@@ -46,6 +46,9 @@ app.post('/interactions', async function (req, res) {
         type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
         data: {
           content: await getServerLeaderboard(req.body.guild.id),
+          allowed_mentions: {
+            parse: [],
+          },
         },
       });
     }


### PR DESCRIPTION
When running the /leaderboard command, 3 members of the Discord server will be mentioned and notified. To prevent this from happening, I added the allowed_mentions object to suppress these mentions.